### PR TITLE
Create uri.js

### DIFF
--- a/src/_utils/join-uri/__tests__/uri.js
+++ b/src/_utils/join-uri/__tests__/uri.js
@@ -1,0 +1,71 @@
+import test from "ava"
+
+import { sep } from "path"
+
+import joinUri from ".."
+
+// Tests for URIs
+test("should preserve protocol-relative uri", (t) => (
+  t.is(joinUri("//some.site", "page"),
+  "//some.site/page")
+))
+
+test("should preserve proto with slashed arg", (t) => (
+  t.is(joinUri("//some.site/", "///page/thing/"),
+  "//some.site/page/thing/")
+))
+
+test("should preserve schema", (t) => (
+  t.is(joinUri("https://some.site", "page"),
+  "https://some.site/page")
+))
+
+test("should preserve trailing slash", (t) => (
+  t.is(joinUri("https://some.site", "page/"),
+  "https://some.site/page/")
+))
+
+test("should remove duplicate slash after TLD", (t) => (
+  t.is(joinUri("https://some.site/", "/page/"),
+  "https://some.site/page/")
+))
+
+test("should remove duplicate slashes", (t) => (
+  t.is(joinUri("https://some.site/", "/page/", "/index.html"),
+  "https://some.site/page/index.html")
+))
+
+test("should join query param to root", (t) => (
+  t.is(
+    joinUri("https://some.site/", "?query=text"),
+    "https://some.site?query=text"
+  )
+))
+
+test("should join query param", (t) => (
+  t.is(
+    joinUri("https://some.site", "index.html", "?query=text"),
+    "https://some.site/index.html?query=text"
+  )
+))
+
+test("should join multiple query params", (t) => (
+  t.is(
+    joinUri("https://some.site/", "?first=1", "?second=2"),
+    "https://some.site/?first=1&second=2"
+  )
+))
+
+test("should join relative URI parts", (t) => (
+  t.is(
+    joinUri("some", "thing"),
+    "some/thing"
+  )
+))
+
+test("should join multipe relative URI parts", (t) => (
+  t.is(
+    joinUri("some", "thing", "else"),
+    "some/thing/else"
+  )
+))


### PR DESCRIPTION
The `join-uri` package has some weird semantics, acting both as a unix/windows filepath fixer, as well as (allegedly) for fixing extra slashes in URIs. Right now specifying a scheme in a URI is broken.

I added some (mostly failing) tests for `join-uri`, in advance of a larger refactor. I hope it helps.

I might recommend that someone with more knowledge of the situation identify the separate scenarios where `join-uri` is used,:
1. Where `join-uri` is used for joining unix or windows paths.
2. Where `join-uri` is used for actual URIs.

It might make sense to use a separate utility for each, as they are separate things, and (it seems) good tools might exist for one or the other, but not both.

I understand that there's some mixing since Phenomic URLs are based on filesystem paths, so it gets a little weird. The windows support thing makes it less clean for URIs (normally a "hybrid" approach using filepath as a subset of URI would be fine. URI as a subset of filepath, as is now the case, is somewhat buggy and incomplete). The current implementation of `join-uri` supports filesystem paths primarily.

I didn't want to make a larger change, and end up breaking something, since I would end up touching about 20 files.
